### PR TITLE
    "msg": "Internal server error",

### DIFF
--- a/models/uploadpaper.model.js
+++ b/models/uploadpaper.model.js
@@ -19,8 +19,8 @@ const UploadSchema = new mongoose.Schema({
     type:Date,
     default:Date.now,
   },
-  likeCount: { type: [String], default: [] }, 
-dislikeCount: { type: [String], default: [] },
+  likeCount:[] , 
+dislikeCount:[] ,
   
   userId:{
     type:mongoose.Schema.Types.ObjectId,


### PR DESCRIPTION
    "success": false,
    "error": "The field 'dislikeCount' must be an array but is of type int in document {_id: ObjectId('66a6331edd70e5b77542544b')}"
} error fixed